### PR TITLE
fix: enable DNS rebinding protection in OAuth mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 GARMIN_EMAIL=x GARMIN_PASSWORD=y ~/.local/bin/uv run garmin-mcp
 
 # Run the server in SSE/HTTP mode with OAuth
-MCP_MODE=sse MCP_API_KEY=secret MCP_SERVER_URL=https://garminmcp.spider.org \
+MCP_MODE=sse MCP_API_KEY=secret MCP_SERVER_URL=https://your-server.example.com \
   ~/.local/bin/uv run garmin-mcp
 
 # End-to-end OAuth PKCE test against live server
@@ -111,10 +111,11 @@ Fully in-memory; all state is lost on container restart (tokens, registered clie
 | `MCP_API_KEY` | No | Bearer token; enables OAuth server when set in SSE mode |
 | `MCP_SERVER_URL` | No (default `http://localhost:8000`) | Public base URL for OAuth issuer/resource metadata |
 | `MCP_TOTP_SECRET` | Yes (when `MCP_API_KEY` set) | Base32 TOTP secret; required for OAuth mode to prevent unauthorized token issuance |
+| `MCP_ALLOWED_HOSTS` | No | Extra allowed Host headers (comma-separated); `MCP_SERVER_URL` hostname is always included |
 | `MCP_HOST` | No (default `0.0.0.0`) | SSE bind address |
 | `MCP_PORT` | No (default `8000`) | SSE port |
 | `GARMIN_SESSION_DIR` | No (default `config/.session`) | garth token cache directory |
 
 ## Testing
 
-Tests live in `tests/`. `pytest-asyncio` is configured with `asyncio_mode = "auto"`. Tests mock the Garmin API — no live credentials needed. The `test_mcp_oauth.py` script in the repo root requires a live server at `https://garminmcp.spider.org` and is run manually, not via pytest.
+Tests live in `tests/`. `pytest-asyncio` is configured with `asyncio_mode = "auto"`. Tests mock the Garmin API — no live credentials needed. The `test_mcp_oauth.py` script in the repo root requires a live server at `https://your-server.example.com` and is run manually, not via pytest.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,6 +62,17 @@ The `_TOTPGateMiddleware` intercepts `GET /authorize` and renders an HTML form r
 
 Without `/authorize` gated by TOTP, the OAuth provider auto-approves all requests — meaning anyone who discovers the server URL gets full access to all Garmin health data via the OAuth flow.
 
+### DNS rebinding protection
+
+When `MCP_API_KEY` is set, the server enables the MCP SDK's DNS rebinding protection. This validates the `Host` header on incoming requests, rejecting any that don't match an allowed hostname. The allowed hostname is automatically derived from `MCP_SERVER_URL`.
+
+To allow additional hosts (e.g., LAN IPs for direct access), set `MCP_ALLOWED_HOSTS` to a comma-separated list:
+```
+MCP_ALLOWED_HOSTS=192.168.1.100,myserver.local
+```
+
+When `MCP_API_KEY` is **not** set (unauthenticated dev mode), DNS rebinding protection is disabled to allow localhost access without configuration.
+
 ---
 
 ## 4. Input Validation

--- a/src/garmin_mcp/server.py
+++ b/src/garmin_mcp/server.py
@@ -9,7 +9,7 @@ import secrets
 import time
 from datetime import date
 from typing import Any
-from urllib.parse import parse_qs, urlencode
+from urllib.parse import parse_qs, urlencode, urlparse
 
 _logger = logging.getLogger(__name__)
 
@@ -942,9 +942,6 @@ def main():
         from mcp.server.transport_security import TransportSecuritySettings
         mcp.settings.host = os.environ.get("MCP_HOST", "0.0.0.0")
         mcp.settings.port = int(os.environ.get("MCP_PORT", "8000"))
-        mcp.settings.transport_security = TransportSecuritySettings(
-            enable_dns_rebinding_protection=False
-        )
         api_key = os.environ.get("MCP_API_KEY", "").strip()
         if api_key:
             import anyio
@@ -954,6 +951,18 @@ def main():
             from mcp.server.fastmcp.server import AuthSettings
 
             server_url = os.environ.get("MCP_SERVER_URL", "http://localhost:8000").rstrip("/")
+            server_host = urlparse(server_url).hostname or "localhost"
+            allowed_hosts = [server_host]
+            extra_hosts = os.environ.get("MCP_ALLOWED_HOSTS", "").strip()
+            if extra_hosts:
+                allowed_hosts.extend(
+                    h.strip() for h in extra_hosts.split(",") if h.strip()
+                )
+            mcp.settings.transport_security = TransportSecuritySettings(
+                enable_dns_rebinding_protection=True,
+                allowed_hosts=allowed_hosts,
+            )
+            _logger.info("DNS rebinding protection enabled, allowed_hosts=%s", allowed_hosts)
             totp_secret = os.environ.get("MCP_TOTP_SECRET", "").strip()
             if not totp_secret:
                 _logger.error(
@@ -1006,6 +1015,9 @@ def main():
             import anyio
             import uvicorn
 
+            mcp.settings.transport_security = TransportSecuritySettings(
+                enable_dns_rebinding_protection=False
+            )
             _logger.warning(
                 "MCP_API_KEY not set — endpoint is unauthenticated. "
                 "Set MCP_API_KEY to require Bearer token auth."


### PR DESCRIPTION
## Summary

- Enables MCP SDK DNS rebinding protection when `MCP_API_KEY` is set (OAuth mode)
- Allowed hostname is automatically derived from `MCP_SERVER_URL` — no extra config needed
- Optional `MCP_ALLOWED_HOSTS` env var for additional hosts (e.g., LAN IPs)
- Protection remains disabled in unauthenticated dev mode (no `MCP_API_KEY`)
- Replaces leaked hostname with placeholder in CLAUDE.md

## Test plan

- [x] Full suite: 119/119 passing, zero regressions
- [ ] Manual: verify server starts with `MCP_SERVER_URL` set, rejects requests with wrong Host header

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)