### PR TITLE
security: redact OAuth secrets from logs unless MCP_DEBUG=true

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ Fully in-memory; all state is lost on container restart (tokens, registered clie
 | `MCP_SERVER_URL` | No (default `http://localhost:8000`) | Public base URL for OAuth issuer/resource metadata |
 | `MCP_TOTP_SECRET` | Yes (when `MCP_API_KEY` set) | Base32 TOTP secret; required for OAuth mode to prevent unauthorized token issuance |
 | `MCP_ALLOWED_HOSTS` | No | Extra allowed Host headers (comma-separated); `MCP_SERVER_URL` hostname is always included |
+| `MCP_DEBUG` | No | Set to `true` to log full OAuth token request/response bodies and Bearer token prefixes. Off by default to prevent secret leakage |
 | `MCP_HOST` | No (default `0.0.0.0`) | SSE bind address |
 | `MCP_PORT` | No (default `8000`) | SSE port |
 | `GARMIN_SESSION_DIR` | No (default `config/.session`) | garth token cache directory |

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Replace `localhost` with your server's IP or hostname if running remotely.
 | `MCP_API_KEY` | No | — | Bearer token; enables OAuth server. Strongly recommended when exposing over the internet |
 | `MCP_TOTP_SECRET` | Yes (when `MCP_API_KEY` set) | — | Base32 TOTP secret for 2FA on OAuth `/authorize`. Required to prevent unauthorized token issuance. Generate with: `python3 -c "import pyotp; print(pyotp.random_base32())"` |
 | `MCP_SERVER_URL` | No | `http://localhost:8000` | Public base URL for OAuth issuer/resource metadata |
+| `MCP_DEBUG` | No | — | Set to `true` to log full OAuth token bodies and Bearer token prefixes. Off by default to prevent secret leakage in logs |
 | `MCP_HOST` | No | `0.0.0.0` | SSE bind address |
 | `MCP_PORT` | No | `8000` | SSE port |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -90,7 +90,21 @@ The `days` cap at 90 also serves as a rate-limit safety net. Without it, `get_hr
 
 ---
 
-## 5. Known Limitations
+## 5. Log Redaction (`MCP_DEBUG`)
+
+By default, the ASGI middleware stack **redacts** sensitive material from logs:
+
+| Middleware | Default (safe) | `MCP_DEBUG=true` |
+|-----------|---------------|-----------------|
+| `_RequestLogMiddleware` | `auth=Bearer ***` | `auth=Bearer <first 10 chars>...` |
+| `_TokenEndpointMiddleware` (request) | Body length only | Full POST body (grant_type, code, etc.) |
+| `_TokenEndpointMiddleware` (response) | `token_type` + `scope` + length | Full JSON including `access_token` and `refresh_token` |
+
+Set `MCP_DEBUG=true` **only** when actively troubleshooting OAuth flows. Never leave it enabled in production — token values in logs can be used to impersonate users.
+
+---
+
+## 6. Known Limitations
 
 ### MFA is not supported
 
@@ -110,7 +124,7 @@ The tool modules (`health.py`, `activities.py`, `training.py`) use bare `except 
 
 ---
 
-## 6. For Contributors
+## 7. For Contributors
 
 ### Do NOT:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       MCP_MODE: sse
       MCP_API_KEY: ${MCP_API_KEY:-}
       MCP_TOTP_SECRET: ${MCP_TOTP_SECRET:-}
+      MCP_DEBUG: ${MCP_DEBUG:-}
     volumes:
       - garmin-session:/app/config/.session
     restart: unless-stopped

--- a/src/garmin_mcp/server.py
+++ b/src/garmin_mcp/server.py
@@ -12,6 +12,7 @@ from typing import Any
 from urllib.parse import parse_qs, urlencode, urlparse
 
 _logger = logging.getLogger(__name__)
+_DEBUG = os.environ.get("MCP_DEBUG", "").strip().lower() in ("1", "true", "yes")
 
 from mcp.server.fastmcp import FastMCP
 
@@ -444,7 +445,10 @@ class _RequestLogMiddleware:
             auth_raw = headers.get(b"authorization", b"").decode("utf-8", errors="replace")
             if auth_raw:
                 parts = auth_raw.split(" ", 1)
-                auth_preview = f"{parts[0]} {parts[1][:10]}..." if len(parts) == 2 else auth_raw[:15]
+                if _DEBUG:
+                    auth_preview = f"{parts[0]} {parts[1][:10]}..." if len(parts) == 2 else auth_raw[:15]
+                else:
+                    auth_preview = f"{parts[0]} ***" if len(parts) == 2 else "(redacted)"
             else:
                 auth_preview = "(none)"
             # Real client IP: Cloudflare Tunnel forwards it in CF-Connecting-IP.
@@ -661,8 +665,12 @@ class _TokenEndpointMiddleware:
                 req_chunks.append(message.get("body", b""))
                 if not message.get("more_body", False):
                     req_body = b"".join(req_chunks)
-                    _logger.info("TOKEN REQUEST body: %s",
-                                 req_body.decode("utf-8", errors="replace")[:500])
+                    if _DEBUG:
+                        _logger.info("TOKEN REQUEST body: %s",
+                                     req_body.decode("utf-8", errors="replace")[:500])
+                    else:
+                        _logger.info("TOKEN REQUEST body: (%d bytes, set MCP_DEBUG=true to log)",
+                                     len(req_body))
             return message
 
         captured_start = None
@@ -689,7 +697,10 @@ class _TokenEndpointMiddleware:
         try:
             data = json.loads(body)
         except Exception:
-            _logger.info("TOKEN RESPONSE (non-JSON): %s", body[:300])
+            if _DEBUG:
+                _logger.info("TOKEN RESPONSE (non-JSON): %s", body[:300])
+            else:
+                _logger.info("TOKEN RESPONSE (non-JSON, %d bytes)", len(body))
             return body
 
         # RFC 8707 §3.2: include resource when it was in the request
@@ -697,7 +708,11 @@ class _TokenEndpointMiddleware:
             data["resource"] = self._resource_url
 
         result = json.dumps(data).encode()
-        _logger.info("TOKEN RESPONSE: %s", result.decode()[:500])
+        if _DEBUG:
+            _logger.info("TOKEN RESPONSE: %s", result.decode()[:500])
+        else:
+            _logger.info("TOKEN RESPONSE: token_type=%s scope=%s (%d bytes)",
+                         data.get("token_type", "?"), data.get("scope", "?"), len(result))
         return result
 
 

--- a/tests/test_debug_redaction.py
+++ b/tests/test_debug_redaction.py
@@ -1,0 +1,190 @@
+"""Tests for MCP_DEBUG-gated log redaction in ASGI middleware."""
+
+import json
+import logging
+
+import pytest
+
+
+async def _simple_app(scope, receive, send):
+    """Minimal ASGI app that always returns 200 OK."""
+    await send({
+        "type": "http.response.start",
+        "status": 200,
+        "headers": [(b"content-type", b"text/plain")],
+    })
+    await send({"type": "http.response.body", "body": b"OK", "more_body": False})
+
+
+async def _token_app(scope, receive, send):
+    """ASGI app that reads the request body and returns a JSON token response."""
+    # Must call receive() so _TokenEndpointMiddleware's logging_receive fires
+    await receive()
+    await send({
+        "type": "http.response.start",
+        "status": 200,
+        "headers": [(b"content-type", b"application/json")],
+    })
+    body = json.dumps({
+        "access_token": "super-secret-token-value",
+        "token_type": "Bearer",
+        "scope": "claudeai",
+    }).encode()
+    await send({"type": "http.response.body", "body": body, "more_body": False})
+
+
+def _make_http_scope(path="/test", method="GET", headers=None):
+    return {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "query_string": b"",
+        "headers": headers or [],
+    }
+
+
+class TestRequestLogRedaction:
+    """_RequestLogMiddleware should redact Bearer tokens unless MCP_DEBUG=true."""
+
+    async def test_auth_redacted_by_default(self, monkeypatch, caplog):
+        monkeypatch.setattr("garmin_mcp.server._DEBUG", False)
+        from garmin_mcp.server import _RequestLogMiddleware
+
+        mw = _RequestLogMiddleware(_simple_app)
+        scope = _make_http_scope(headers=[
+            (b"authorization", b"Bearer my-secret-token-12345"),
+        ])
+        responses = []
+
+        async def receive():
+            return {}
+
+        async def send(event):
+            responses.append(event)
+
+        with caplog.at_level(logging.INFO, logger="garmin_mcp.server"):
+            await mw(scope, receive, send)
+
+        req_logs = [r for r in caplog.records if "REQ" in r.message]
+        assert len(req_logs) >= 1
+        assert "my-secret" not in req_logs[0].message
+        assert "Bearer ***" in req_logs[0].message
+
+    async def test_auth_visible_in_debug_mode(self, monkeypatch, caplog):
+        monkeypatch.setattr("garmin_mcp.server._DEBUG", True)
+        from garmin_mcp.server import _RequestLogMiddleware
+
+        mw = _RequestLogMiddleware(_simple_app)
+        scope = _make_http_scope(headers=[
+            (b"authorization", b"Bearer my-secret-token-12345"),
+        ])
+        responses = []
+
+        async def receive():
+            return {}
+
+        async def send(event):
+            responses.append(event)
+
+        with caplog.at_level(logging.INFO, logger="garmin_mcp.server"):
+            await mw(scope, receive, send)
+
+        req_logs = [r for r in caplog.records if "REQ" in r.message]
+        assert len(req_logs) >= 1
+        assert "my-secret" in req_logs[0].message
+
+
+class TestTokenEndpointRedaction:
+    """_TokenEndpointMiddleware should redact request/response bodies unless MCP_DEBUG."""
+
+    async def test_token_request_redacted_by_default(self, monkeypatch, caplog):
+        monkeypatch.setattr("garmin_mcp.server._DEBUG", False)
+        from garmin_mcp.server import _TokenEndpointMiddleware
+
+        mw = _TokenEndpointMiddleware(_token_app, resource_url="https://example.com/mcp")
+        scope = _make_http_scope(path="/token", method="POST")
+        req_body = b"grant_type=authorization_code&code=secret-auth-code"
+
+        async def receive():
+            return {"type": "http.request", "body": req_body, "more_body": False}
+
+        responses = []
+
+        async def send(event):
+            responses.append(event)
+
+        with caplog.at_level(logging.INFO, logger="garmin_mcp.server"):
+            await mw(scope, receive, send)
+
+        req_logs = [r for r in caplog.records if "TOKEN REQUEST body:" in r.message]
+        assert len(req_logs) == 1
+        assert "secret-auth-code" not in req_logs[0].message
+        assert "bytes" in req_logs[0].message
+
+    async def test_token_request_visible_in_debug(self, monkeypatch, caplog):
+        monkeypatch.setattr("garmin_mcp.server._DEBUG", True)
+        from garmin_mcp.server import _TokenEndpointMiddleware
+
+        mw = _TokenEndpointMiddleware(_token_app, resource_url="https://example.com/mcp")
+        scope = _make_http_scope(path="/token", method="POST")
+        req_body = b"grant_type=authorization_code&code=secret-auth-code"
+
+        async def receive():
+            return {"type": "http.request", "body": req_body, "more_body": False}
+
+        responses = []
+
+        async def send(event):
+            responses.append(event)
+
+        with caplog.at_level(logging.INFO, logger="garmin_mcp.server"):
+            await mw(scope, receive, send)
+
+        req_logs = [r for r in caplog.records if "TOKEN REQUEST body:" in r.message]
+        assert len(req_logs) == 1
+        assert "secret-auth-code" in req_logs[0].message
+
+    async def test_token_response_redacted_by_default(self, monkeypatch, caplog):
+        monkeypatch.setattr("garmin_mcp.server._DEBUG", False)
+        from garmin_mcp.server import _TokenEndpointMiddleware
+
+        mw = _TokenEndpointMiddleware(_token_app, resource_url="https://example.com/mcp")
+        scope = _make_http_scope(path="/token", method="POST")
+
+        async def receive():
+            return {"type": "http.request", "body": b"grant_type=authorization_code", "more_body": False}
+
+        responses = []
+
+        async def send(event):
+            responses.append(event)
+
+        with caplog.at_level(logging.INFO, logger="garmin_mcp.server"):
+            await mw(scope, receive, send)
+
+        rsp_logs = [r for r in caplog.records if "TOKEN RESPONSE:" in r.message]
+        assert len(rsp_logs) == 1
+        assert "super-secret-token-value" not in rsp_logs[0].message
+        assert "token_type=Bearer" in rsp_logs[0].message
+
+    async def test_token_response_visible_in_debug(self, monkeypatch, caplog):
+        monkeypatch.setattr("garmin_mcp.server._DEBUG", True)
+        from garmin_mcp.server import _TokenEndpointMiddleware
+
+        mw = _TokenEndpointMiddleware(_token_app, resource_url="https://example.com/mcp")
+        scope = _make_http_scope(path="/token", method="POST")
+
+        async def receive():
+            return {"type": "http.request", "body": b"grant_type=authorization_code", "more_body": False}
+
+        responses = []
+
+        async def send(event):
+            responses.append(event)
+
+        with caplog.at_level(logging.INFO, logger="garmin_mcp.server"):
+            await mw(scope, receive, send)
+
+        rsp_logs = [r for r in caplog.records if "TOKEN RESPONSE:" in r.message]
+        assert len(rsp_logs) == 1
+        assert "super-secret-token-value" in rsp_logs[0].message


### PR DESCRIPTION
## Summary

- Gate sensitive OAuth token/auth logging behind `MCP_DEBUG` env var (default off)
- `_RequestLogMiddleware`: redact Bearer token to `Bearer ***` in normal mode
- `_TokenEndpointMiddleware`: log only body length and safe metadata (token_type, scope) instead of full request/response bodies
- When `MCP_DEBUG=true`, restore full verbose logging for troubleshooting

Closes #4

## Changes

| File | Change |
|------|--------|
| `server.py` | Add `_DEBUG` flag, conditional redaction in 4 logging locations |
| `test_debug_redaction.py` | 6 new tests verifying redaction on/off for auth headers and token bodies |
| `SECURITY.md` | New §5 documenting log redaction behavior |
| `CLAUDE.md`, `README.md` | Add `MCP_DEBUG` to env var tables |
| `docker-compose.yml` | Add `MCP_DEBUG` placeholder |

## Test plan

- [x] All 125 tests pass
- [ ] Deploy with `MCP_DEBUG` unset → verify logs show `Bearer ***` and body lengths only
- [ ] Deploy with `MCP_DEBUG=true` → verify full token bodies appear in logs