### PR TITLE
security: run Docker container as non-root mcp user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,15 @@ RUN uv sync --frozen --no-dev
 # Copy source
 COPY src/ src/
 
+# Non-root user for runtime — session tokens are owned by this user,
+# so 0700 permissions in garmin_client.py are meaningful.
+RUN groupadd --gid 1000 mcp && \
+    useradd --uid 1000 --gid mcp --no-create-home mcp
+
 # Session token cache lives here; mount a volume to persist across restarts
-RUN mkdir -p config/.session
+RUN mkdir -p config/.session && chown -R mcp:mcp config/
+
+USER mcp
 
 # SSE transport — clients connect to http://<host>:8000/sse
 EXPOSE 8000

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,6 +24,7 @@ Garmin credentials are passed **exclusively via environment variables** (`GARMIN
 Garmin OAuth tokens (managed by the `garth` library) are cached on disk to avoid re-authentication on every server restart.
 
 - **Location**: `config/.session/` (configurable via `GARMIN_SESSION_DIR` env var); mounted as a named Docker volume in the container
+- **Non-root container**: The Docker image runs as a dedicated `mcp` user (UID 1000), not root. This makes the `0700` directory permissions meaningful — only the `mcp` user can read session tokens, not other processes or containers sharing the host
 - **Directory permissions**: `0700` (owner-only rwx), enforced by `os.chmod()` in `garmin_client.py` every time `_authenticate()` runs
 - **TTL**: Garmin tokens typically expire after ~24 hours. The server handles this via `call_with_retry()`, which catches `GarminConnectAuthenticationError`, invalidates the cached client, and re-authenticates once before retrying the failed call
 - **Persistence failures**: If `garth.dump()` fails, a warning is logged but the server continues operating. The next restart will trigger a full re-authentication


### PR DESCRIPTION
## Summary

- Add dedicated `mcp` user (UID 1000) to Dockerfile instead of running as root
- Session directory `config/.session/` owned by `mcp:mcp` so the existing `0700` permissions in `garmin_client.py` are meaningful
- Reduces blast radius if the container is compromised

Closes #9

## Changes

| File | Change |
|------|--------|
| `Dockerfile` | Add `mcp` user/group, `chown` session dir, `USER mcp` directive |
| `SECURITY.md` | Document non-root container in §2 |

## Test plan

- [x] Docker image builds successfully
- [x] Container runs as `uid=1000(mcp)` (verified with `docker run --rm <image> id`)
- [x] Session directory owned by `mcp:mcp` (verified with `ls -la config/`)
- [x] All 125 tests pass
- [ ] Deploy to Unraid and verify server starts and authenticates with Garmin

### Note for existing deployments

If upgrading from a previous version that ran as root, the existing Docker volume may have files owned by root. The `mcp` user won't be able to read them. Fix by either:
1. Removing the old volume: `docker volume rm garmin-session` (triggers re-auth on next start)
2. Or fixing ownership: `docker run --rm -v garmin-session:/data alpine chown -R 1000:1000 /data`