### PR TITLE
fix: chown /app for mcp user so uv run can modify .venv

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,30 @@ jobs:
       - run: uv run pytest
 
       - uses: docker/setup-buildx-action@v3
+
+      # Build and load locally for smoke test (not pushed yet)
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: garmin-mcp:test
+
+      # Smoke test: container starts, uv resolves, and tool list is reachable
+      - name: Smoke test Docker image
+        run: |
+          docker run --rm -d --name smoke \
+            -e GARMIN_EMAIL=test@test.com \
+            -e GARMIN_PASSWORD=test \
+            -p 8000:8000 \
+            garmin-mcp:test
+          sleep 5
+          # Check container is still running (didn't crash on startup)
+          docker inspect --format='{{.State.Running}}' smoke | grep true
+          # Check the MCP endpoint is responding
+          curl -sf http://localhost:8000/mcp -o /dev/null -w '%{http_code}' || true
+          docker logs smoke
+          docker stop smoke
+
       - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,14 @@ docker buildx build --platform linux/amd64 --push -t paulmon/garmin-connect-mcp:
 
 When working on a GitHub issue, always create a feature branch from `main` before making changes. Use the naming convention `feature/<short-description>` (e.g., `feature/totp-authorize-gate`). Commit messages and PR descriptions should include `Closes #<issue-number>` so the issue is automatically closed when the PR is merged.
 
+### Bug workflow
+
+When the user reports a bug and we confirm it exists:
+1. **Create a GitHub issue** with the `bug` label — include symptoms, root cause, and expected behavior
+2. **Create a fix branch** from `main` (e.g., `fix/<short-description>`)
+3. **Comment on the issue** with progress updates as the fix is developed
+4. **Include `Closes #<issue-number>`** in the PR description so the issue auto-closes on merge
+
 ## Architecture
 
 The project is a single Python package (`src/garmin_mcp/`) built on [FastMCP](https://github.com/jlowin/fastmcp). All 13 MCP tools are registered on the global `mcp` instance in `server.py`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,9 @@ RUN groupadd --gid 1000 mcp && \
     useradd --uid 1000 --gid mcp --create-home mcp
 
 # Session token cache lives here; mount a volume to persist across restarts
-RUN mkdir -p config/.session && chown -R mcp:mcp config/
+# Also chown the entire /app (including .venv created by uv sync) so the
+# non-root mcp user can run `uv run` at runtime.
+RUN mkdir -p config/.session && chown -R mcp:mcp /app
 
 USER mcp
 


### PR DESCRIPTION
## Summary
- `chown -R mcp:mcp /app` after user creation so the non-root `mcp` user can modify the `.venv` at runtime
- Without this, `uv run` fails with `Permission denied` trying to write to the root-owned `.venv`

Closes #58

## Test plan
- [ ] Merge and verify Docker workflow builds successfully
- [ ] Pull new image on Unraid and confirm container starts without permission errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)