### PR TITLE
feat: add 3 steps MCP tools

### DIFF
--- a/src/garmin_mcp/server.py
+++ b/src/garmin_mcp/server.py
@@ -419,6 +419,50 @@ def get_spo2_data(cdate: str) -> str:
         return NOT_CONFIGURED_MSG
 
 
+@mcp.tool()
+def get_steps_data(cdate: str) -> str:
+    """Get intraday step data for a given date (YYYY-MM-DD) with per-interval
+    breakdowns showing when steps were accumulated throughout the day."""
+    from .tools.health import get_steps_data as _get
+
+    cdate = _validate_date(cdate)
+    try:
+        result = _get_client().call_with_retry(lambda api: _get(api, cdate=cdate))
+        return _to_json(result)
+    except CredentialsNotConfiguredError:
+        return NOT_CONFIGURED_MSG
+
+
+@mcp.tool()
+def get_daily_steps(start: str, end: str) -> str:
+    """Get daily step counts between two dates (YYYY-MM-DD). Returns step
+    totals for each day in the range."""
+    from .tools.health import get_daily_steps as _get
+
+    start = _validate_date(start)
+    end = _validate_date(end)
+    try:
+        result = _get_client().call_with_retry(lambda api: _get(api, start=start, end=end))
+        return _to_json(result)
+    except CredentialsNotConfiguredError:
+        return NOT_CONFIGURED_MSG
+
+
+@mcp.tool()
+def get_weekly_steps(end: str, weeks: int = 4) -> str:
+    """Get weekly step aggregates ending on a date (YYYY-MM-DD).
+    Returns step totals by week. Max 12 weeks."""
+    from .tools.health import get_weekly_steps as _get
+
+    end = _validate_date(end)
+    weeks = max(1, min(weeks, _MAX_WEEKS))
+    try:
+        result = _get_client().call_with_retry(lambda api: _get(api, end=end, weeks=weeks))
+        return _to_json(result)
+    except CredentialsNotConfiguredError:
+        return NOT_CONFIGURED_MSG
+
+
 # --- Training tools ---
 
 

--- a/src/garmin_mcp/tools/health.py
+++ b/src/garmin_mcp/tools/health.py
@@ -322,6 +322,56 @@ def get_spo2_data(
     return data
 
 
+def get_steps_data(
+    api: Garmin,
+    cdate: str,
+) -> dict[str, Any]:
+    """Get intraday step data with per-interval breakdowns for a given date."""
+    try:
+        data = api.get_steps_data(cdate)
+    except Exception:
+        return {}
+
+    if not data:
+        return {}
+
+    return data
+
+
+def get_daily_steps(
+    api: Garmin,
+    start: str,
+    end: str,
+) -> dict[str, Any]:
+    """Get daily step counts between two dates."""
+    try:
+        data = api.get_daily_steps(start, end)
+    except Exception:
+        return {}
+
+    if not data:
+        return {}
+
+    return data
+
+
+def get_weekly_steps(
+    api: Garmin,
+    end: str,
+    weeks: int = 4,
+) -> dict[str, Any]:
+    """Get weekly step aggregates."""
+    try:
+        data = api.get_weekly_steps(end, weeks)
+    except Exception:
+        return {}
+
+    if not data:
+        return {}
+
+    return data
+
+
 def get_resting_hr_trend(
     api: Garmin,
     days: int = 14,

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -8,6 +8,7 @@ from garmin_mcp.tools.health import (
     get_body_battery,
     get_body_battery_events,
     get_daily_stats,
+    get_daily_steps,
     get_heart_rates,
     get_hrv_trend,
     get_intensity_minutes,
@@ -15,8 +16,10 @@ from garmin_mcp.tools.health import (
     get_resting_hr_trend,
     get_sleep_history,
     get_spo2_data,
+    get_steps_data,
     get_stress_data,
     get_weekly_intensity_minutes,
+    get_weekly_steps,
     get_weekly_stress,
 )
 
@@ -587,3 +590,93 @@ class TestGetSpo2Data:
         api.get_spo2_data.side_effect = Exception("fail")
 
         assert get_spo2_data(api, cdate="2025-01-15") == {}
+
+
+# --- get_steps_data ---
+
+
+class TestGetStepsData:
+    def test_returns_steps_data(self):
+        api = MagicMock()
+        api.get_steps_data.return_value = {
+            "calendarDate": "2025-01-15",
+            "totalSteps": 8432,
+            "totalDistance": 6200,
+            "stepGoal": 10000,
+        }
+
+        result = get_steps_data(api, cdate="2025-01-15")
+
+        assert result["totalSteps"] == 8432
+        api.get_steps_data.assert_called_once_with("2025-01-15")
+
+    def test_returns_empty_on_none(self):
+        api = MagicMock()
+        api.get_steps_data.return_value = None
+
+        assert get_steps_data(api, cdate="2025-01-15") == {}
+
+    def test_returns_empty_on_exception(self):
+        api = MagicMock()
+        api.get_steps_data.side_effect = Exception("fail")
+
+        assert get_steps_data(api, cdate="2025-01-15") == {}
+
+
+# --- get_daily_steps ---
+
+
+class TestGetDailySteps:
+    def test_returns_daily_steps(self):
+        api = MagicMock()
+        api.get_daily_steps.return_value = [
+            {"calendarDate": "2025-01-14", "totalSteps": 9500},
+            {"calendarDate": "2025-01-15", "totalSteps": 8432},
+        ]
+
+        result = get_daily_steps(api, start="2025-01-14", end="2025-01-15")
+
+        assert len(result) == 2
+        api.get_daily_steps.assert_called_once_with("2025-01-14", "2025-01-15")
+
+    def test_returns_empty_on_none(self):
+        api = MagicMock()
+        api.get_daily_steps.return_value = None
+
+        assert get_daily_steps(api, start="2025-01-14", end="2025-01-15") == {}
+
+    def test_returns_empty_on_exception(self):
+        api = MagicMock()
+        api.get_daily_steps.side_effect = Exception("fail")
+
+        assert get_daily_steps(api, start="2025-01-14", end="2025-01-15") == {}
+
+
+# --- get_weekly_steps ---
+
+
+class TestGetWeeklySteps:
+    def test_returns_weekly_steps(self):
+        api = MagicMock()
+        api.get_weekly_steps.return_value = {
+            "startDate": "2025-01-01",
+            "endDate": "2025-01-15",
+            "weeklyStepAverages": [{"calendarDate": "2025-01-15", "averageSteps": 9200}],
+        }
+
+        result = get_weekly_steps(api, end="2025-01-15", weeks=2)
+
+        assert "weeklyStepAverages" in result
+        api.get_weekly_steps.assert_called_once_with("2025-01-15", 2)
+
+    def test_returns_empty_on_none(self):
+        api = MagicMock()
+        api.get_weekly_steps.return_value = None
+
+        assert get_weekly_steps(api, end="2025-01-15", weeks=2) == {}
+
+    def test_returns_empty_on_exception(self):
+        api = MagicMock()
+        api.get_weekly_steps.side_effect = Exception("fail")
+
+        assert get_weekly_steps(api, end="2025-01-15", weeks=2) == {}

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -135,7 +135,7 @@ class TestMcpProtocol:
             },
         )
         tools = resp.json()["result"]["tools"]
-        assert len(tools) == 42
+        assert len(tools) == 45
 
     def test_list_tools_names(self, mcp_client):
         resp = mcp_client.post(
@@ -408,6 +408,29 @@ class TestHealthTools:
         mock_api.get_weekly_intensity_minutes.return_value = {"weeks": [{"total": 150}]}
         result = _call_tool(mcp_client, "get_weekly_intensity_minutes", {"end": "2025-01-15"})
         assert "weeks" in result
+
+    def test_get_steps_data(self, mcp_client, mock_api):
+        mock_api.get_steps_data.return_value = {
+            "calendarDate": "2025-01-15",
+            "totalSteps": 8432,
+        }
+        result = _call_tool(mcp_client, "get_steps_data", {"cdate": "2025-01-15"})
+        assert result["totalSteps"] == 8432
+
+    def test_get_daily_steps(self, mcp_client, mock_api):
+        mock_api.get_daily_steps.return_value = [
+            {"calendarDate": "2025-01-14", "totalSteps": 9500},
+            {"calendarDate": "2025-01-15", "totalSteps": 8432},
+        ]
+        result = _call_tool(mcp_client, "get_daily_steps", {"start": "2025-01-14", "end": "2025-01-15"})
+        assert len(result) == 2
+
+    def test_get_weekly_steps(self, mcp_client, mock_api):
+        mock_api.get_weekly_steps.return_value = {
+            "weeklyStepAverages": [{"calendarDate": "2025-01-15", "averageSteps": 9200}],
+        }
+        result = _call_tool(mcp_client, "get_weekly_steps", {"end": "2025-01-15"})
+        assert "weeklyStepAverages" in result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server_startup.py
+++ b/tests/test_server_startup.py
@@ -8,7 +8,7 @@ class TestMcpServerRegistration:
         from garmin_mcp.server import mcp
 
         tools = mcp._tool_manager.list_tools()
-        assert len(tools) == 42
+        assert len(tools) == 45
 
     def test_mcp_server_tool_names(self):
         from garmin_mcp.server import mcp
@@ -57,6 +57,9 @@ class TestMcpServerRegistration:
             "get_respiration_data",
             "get_spo2_data",
             "upload_cycling_workout",
+            "get_steps_data",
+            "get_daily_steps",
+            "get_weekly_steps",
         }
         assert names == expected
 


### PR DESCRIPTION
## Summary
- **get_steps_data** (#14): intraday step data with per-interval breakdowns for a given date
- **get_daily_steps** (#15): daily step counts between two dates
- **get_weekly_steps** (#16): weekly step aggregates (max 12 weeks)

Closes #14, closes #15, closes #16

## Changes
- 3 new functions in `src/garmin_mcp/tools/health.py`
- 3 new tool registrations in `src/garmin_mcp/server.py`
- 9 new unit tests in `tests/test_health.py`
- 3 new integration tests in `tests/test_mcp_integration.py`
- Tool count updated to 45 in startup and integration tests

## Test plan
- [x] All 279 tests pass locally
- [x] Ruff lint + format clean
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)