### PR TITLE
docs: remove OAuth bug note and add Cloudflare tunnel tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ Use the full path to `uv` (find it with `which uv`). Quit and relaunch Claude De
 
 ## Option B — Docker (SSE, remote-friendly)
 
-> **Note:** Remote MCP via claude.ai is currently broken due to an OAuth bug on Anthropic's side. The OAuth PKCE flow completes successfully but claude.ai fails to use the issued token. This does not affect Claude Desktop connecting to a remote server (which uses direct Bearer token auth). This note will be removed once the bug is resolved.
-
 Best for running on a home server or NAS so Claude on any device (Desktop, mobile, web) can reach it.
+
+> **Tip:** If you use Cloudflare Tunnel (`cloudflared`) to expose your container to the internet, make sure your Cloudflare zone's **Bot Fight Mode** / **AI Bot Prevention** is not blocking MCP requests. You can check this in **Cloudflare Dashboard → Security → Bots**. Use **Workers Observability** or **Cloudflare Logs** to verify requests are reaching your origin — Cloudflare may silently block requests it classifies as automated.
 
 ### Requirements
 


### PR DESCRIPTION
## Summary
- Removed the OAuth bug note — the claude.ai remote MCP OAuth issue has been resolved
- Added a tip for users routing through Cloudflare Tunnel (`cloudflared`) to check Bot Fight Mode / AI Bot Prevention settings, which can silently block MCP requests

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)