### PR TITLE
fix: persist OAuth tokens to disk so they survive container restarts

### DIFF
--- a/src/garmin_mcp/server.py
+++ b/src/garmin_mcp/server.py
@@ -827,24 +827,91 @@ def get_body_composition(days: int = 30) -> str:
 
 
 class _SimpleOAuthProvider:
-    """Minimal in-memory OAuth 2.0 provider for personal use.
+    """Minimal OAuth 2.0 provider for personal use.
 
-    Auto-approves every authorization request and issues MCP_API_KEY as the
-    access token. All state is in memory and resets on container restart.
+    Auto-approves every authorization request and issues random tokens.
+    Persistent state (clients, access tokens, refresh tokens) is saved to
+    *persist_path* so tokens survive container restarts.  Auth codes are
+    short-lived and kept only in memory.
     """
 
-    def __init__(self, api_key: str) -> None:
+    def __init__(self, api_key: str, persist_path: str | None = None) -> None:
         self._api_key = api_key
+        self._persist_path = persist_path
         self._clients: dict = {}
         self._auth_codes: dict = {}
         self._access_tokens: dict = {}  # token → scopes
         self._refresh_tokens: dict = {}
+        self._load()
+
+    # -- persistence helpers ------------------------------------------------
+
+    def _load(self) -> None:
+        """Restore persistent state from disk (best-effort)."""
+        if not self._persist_path:
+            return
+        from pathlib import Path
+
+        p = Path(self._persist_path)
+        if not p.exists():
+            return
+        try:
+            from mcp.server.auth.provider import RefreshToken
+
+            data = json.loads(p.read_text())
+            # clients — stored as Pydantic model dicts
+            from mcp.server.auth.provider import OAuthClientInformationFull
+
+            for cid, raw in data.get("clients", {}).items():
+                self._clients[cid] = OAuthClientInformationFull.model_validate(raw)
+            # access tokens — simple {token: [scopes]}
+            self._access_tokens = {
+                tok: scopes for tok, scopes in data.get("access_tokens", {}).items()
+            }
+            # refresh tokens — {token: {token, client_id, scopes}}
+            for tok, raw in data.get("refresh_tokens", {}).items():
+                self._refresh_tokens[tok] = RefreshToken.model_validate(raw)
+            _logger.info(
+                "OAuth state restored: %d clients, %d access tokens, %d refresh tokens",
+                len(self._clients),
+                len(self._access_tokens),
+                len(self._refresh_tokens),
+            )
+        except Exception:
+            _logger.warning("Failed to load OAuth state from %s", p, exc_info=True)
+
+    def _save(self) -> None:
+        """Persist durable state to disk (best-effort)."""
+        if not self._persist_path:
+            return
+        from pathlib import Path
+
+        p = Path(self._persist_path)
+        try:
+            p.parent.mkdir(parents=True, exist_ok=True)
+            data = {
+                "clients": {
+                    cid: info.model_dump(mode="json") for cid, info in self._clients.items()
+                },
+                "access_tokens": self._access_tokens,
+                "refresh_tokens": {
+                    tok: rt.model_dump(mode="json") for tok, rt in self._refresh_tokens.items()
+                },
+            }
+            tmp = p.with_suffix(".tmp")
+            tmp.write_text(json.dumps(data))
+            tmp.replace(p)
+        except Exception:
+            _logger.warning("Failed to save OAuth state to %s", p, exc_info=True)
+
+    # -- OAuthProvider interface -------------------------------------------
 
     async def get_client(self, client_id: str):
         return self._clients.get(client_id)
 
     async def register_client(self, client_info) -> None:
         self._clients[client_info.client_id] = client_info
+        self._save()
 
     async def authorize(self, client, params) -> str:
         from mcp.server.auth.provider import AuthorizationCode, construct_redirect_uri
@@ -875,6 +942,7 @@ class _SimpleOAuthProvider:
         self._refresh_tokens[refresh] = RefreshToken(
             token=refresh, client_id=client.client_id, scopes=authorization_code.scopes
         )
+        self._save()
         return OAuthToken(
             access_token=access,
             token_type="Bearer",  # nosec B106
@@ -912,6 +980,7 @@ class _SimpleOAuthProvider:
         self._refresh_tokens[new_refresh] = RefreshToken(
             token=new_refresh, client_id=client.client_id, scopes=refresh_token.scopes
         )
+        self._save()
         return OAuthToken(
             access_token=access,
             token_type="Bearer",  # nosec B106
@@ -927,6 +996,7 @@ class _SimpleOAuthProvider:
             self._refresh_tokens.pop(token.token, None)
         else:
             self._access_tokens.pop(getattr(token, "token", str(token)), None)
+        self._save()
 
     async def verify_token(self, token: str):
         return await self.load_access_token(token)
@@ -1519,7 +1589,9 @@ def main():
                     'python3 -c "import pyotp; print(pyotp.random_base32())"'
                 )
                 raise SystemExit(1)
-            provider = _SimpleOAuthProvider(api_key)
+            session_dir = os.environ.get("GARMIN_SESSION_DIR", "config/.session")
+            oauth_state_path = os.path.join(session_dir, "oauth_state.json")
+            provider = _SimpleOAuthProvider(api_key, persist_path=oauth_state_path)
             mcp._auth_server_provider = provider
             mcp._token_verifier = ProviderTokenVerifier(provider)
             mcp.settings.auth = AuthSettings(

--- a/tests/test_oauth_persistence.py
+++ b/tests/test_oauth_persistence.py
@@ -1,0 +1,188 @@
+"""Tests for OAuth state persistence across provider restarts."""
+
+import json
+import os
+import tempfile
+
+import pytest
+
+
+@pytest.fixture
+def persist_file(tmp_path):
+    """Return a path to a temporary persistence file."""
+    return str(tmp_path / "oauth_state.json")
+
+
+def _make_provider(api_key="test-key", persist_path=None):
+    from garmin_mcp.server import _SimpleOAuthProvider
+
+    return _SimpleOAuthProvider(api_key, persist_path=persist_path)
+
+
+class TestOAuthPersistence:
+    async def test_save_and_restore_clients(self, persist_file):
+        """Registered clients survive a provider restart."""
+        from mcp.server.auth.provider import OAuthClientInformationFull
+
+        provider = _make_provider(persist_path=persist_file)
+        client_info = OAuthClientInformationFull(
+            client_id="claude-web",
+            client_secret="s3cret",
+            redirect_uris=["https://example.com/callback"],
+        )
+        await provider.register_client(client_info)
+
+        # New provider loads from same file
+        provider2 = _make_provider(persist_path=persist_file)
+        restored = await provider2.get_client("claude-web")
+        assert restored is not None
+        assert restored.client_id == "claude-web"
+        assert restored.client_secret == "s3cret"
+
+    async def test_save_and_restore_tokens(self, persist_file):
+        """Access and refresh tokens survive a provider restart."""
+        from mcp.server.auth.provider import (
+            AuthorizationCode,
+            OAuthClientInformationFull,
+        )
+
+        provider = _make_provider(persist_path=persist_file)
+        client_info = OAuthClientInformationFull(
+            client_id="claude-web",
+            client_secret="s3cret",
+            redirect_uris=["https://example.com/callback"],
+        )
+        await provider.register_client(client_info)
+
+        # Simulate issuing tokens via exchange_authorization_code
+        import time
+
+        code_obj = AuthorizationCode(
+            code="test-code",
+            scopes=["claudeai"],
+            expires_at=time.time() + 300,
+            client_id="claude-web",
+            code_challenge="challenge",
+            redirect_uri="https://example.com/callback",
+            redirect_uri_provided_explicitly=True,
+            resource=None,
+        )
+        provider._auth_codes["test-code"] = code_obj
+        token_resp = await provider.exchange_authorization_code(client_info, code_obj)
+
+        access_token = token_resp.access_token
+        refresh_token = token_resp.refresh_token
+
+        # New provider loads from same file
+        provider2 = _make_provider(persist_path=persist_file)
+        loaded_access = await provider2.load_access_token(access_token)
+        assert loaded_access is not None
+        assert loaded_access.scopes == ["claudeai"]
+
+        loaded_refresh = await provider2.load_refresh_token(client_info, refresh_token)
+        assert loaded_refresh is not None
+        assert loaded_refresh.client_id == "claude-web"
+
+    async def test_revoke_persists(self, persist_file):
+        """Revoking a token is persisted so it stays revoked after restart."""
+        from mcp.server.auth.provider import (
+            AuthorizationCode,
+            OAuthClientInformationFull,
+        )
+
+        provider = _make_provider(persist_path=persist_file)
+        client_info = OAuthClientInformationFull(
+            client_id="c1",
+            client_secret="s",
+            redirect_uris=["https://example.com/cb"],
+        )
+        await provider.register_client(client_info)
+
+        import time
+
+        code_obj = AuthorizationCode(
+            code="c",
+            scopes=["claudeai"],
+            expires_at=time.time() + 300,
+            client_id="c1",
+            code_challenge="ch",
+            redirect_uri="https://example.com/cb",
+            redirect_uri_provided_explicitly=True,
+            resource=None,
+        )
+        provider._auth_codes["c"] = code_obj
+        token_resp = await provider.exchange_authorization_code(client_info, code_obj)
+        access_token = token_resp.access_token
+
+        # Revoke it
+        loaded = await provider.load_access_token(access_token)
+        await provider.revoke_token(loaded)
+
+        # After restart the token should still be gone
+        provider2 = _make_provider(persist_path=persist_file)
+        assert await provider2.load_access_token(access_token) is None
+
+    async def test_no_persist_path_works(self):
+        """Provider works fine without persistence (backward compat)."""
+        provider = _make_provider(persist_path=None)
+        from mcp.server.auth.provider import OAuthClientInformationFull
+
+        client_info = OAuthClientInformationFull(
+            client_id="c1",
+            client_secret="s",
+            redirect_uris=["https://example.com/cb"],
+        )
+        await provider.register_client(client_info)
+        assert await provider.get_client("c1") is not None
+
+    async def test_corrupted_file_handled_gracefully(self, persist_file):
+        """Corrupted persistence file doesn't crash the provider."""
+        with open(persist_file, "w") as f:
+            f.write("not valid json{{{")
+
+        # Should not raise
+        provider = _make_provider(persist_path=persist_file)
+        assert await provider.get_client("anything") is None
+
+    async def test_refresh_token_exchange_persists(self, persist_file):
+        """Exchanging a refresh token persists the new tokens."""
+        from mcp.server.auth.provider import (
+            AuthorizationCode,
+            OAuthClientInformationFull,
+        )
+
+        provider = _make_provider(persist_path=persist_file)
+        client_info = OAuthClientInformationFull(
+            client_id="c1",
+            client_secret="s",
+            redirect_uris=["https://example.com/cb"],
+        )
+        await provider.register_client(client_info)
+
+        import time
+
+        code_obj = AuthorizationCode(
+            code="c",
+            scopes=["claudeai"],
+            expires_at=time.time() + 300,
+            client_id="c1",
+            code_challenge="ch",
+            redirect_uri="https://example.com/cb",
+            redirect_uri_provided_explicitly=True,
+            resource=None,
+        )
+        provider._auth_codes["c"] = code_obj
+        token_resp = await provider.exchange_authorization_code(client_info, code_obj)
+        old_refresh = token_resp.refresh_token
+
+        # Exchange the refresh token
+        rt = await provider.load_refresh_token(client_info, old_refresh)
+        new_token_resp = await provider.exchange_refresh_token(client_info, rt, ["claudeai"])
+        new_access = new_token_resp.access_token
+        new_refresh = new_token_resp.refresh_token
+
+        # Restart — new tokens should be valid, old ones gone
+        provider2 = _make_provider(persist_path=persist_file)
+        assert await provider2.load_access_token(new_access) is not None
+        assert await provider2.load_refresh_token(client_info, new_refresh) is not None
+        assert await provider2.load_refresh_token(client_info, old_refresh) is None


### PR DESCRIPTION
The _SimpleOAuthProvider stored all state (clients, access tokens,
refresh tokens) in memory, meaning every container restart required
re-authenticating via OAuth. This was especially painful when updating
the container image for unrelated changes (e.g. README updates).

Now the provider saves durable state to oauth_state.json in the
GARMIN_SESSION_DIR volume (same mount used for Garmin session tokens).
Auth codes remain in-memory only since they expire in 5 minutes.

Closes #62

https://claude.ai/code/session_013ee1EPpUsFoVLzNbXn4G2G